### PR TITLE
Expand checks for popup creation to handle undefined in addition to null

### DIFF
--- a/js/index.js
+++ b/js/index.js
@@ -141,7 +141,8 @@ Map.prototype.getPopupContent = function (districtName, groupNameInPopup, punish
             ((this.populationOfThisGroup === 0) ? groupNameInPopup : punishmentType) +
             "</b> for the <b>" + this.schoolYear + "</b> school year.";
     }
-    else if (this.punishmentTotal !== null && this.populationOfThisGroup !== null){
+    else if (this.punishmentTotal != null && this.punishmentOfThisGroup != null &&
+             this.populationTotal != null && this.populationOfThisGroup != null) {
         const percentStudentsByGroup = Number(this.populationOfThisGroup) * 100.0 / Number(this.populationTotal);
         const punishmentPercent = Number(this.punishmentOfThisGroup) * 100.0 / Number(this.punishmentTotal);
         popupContent = "In <b>" + districtName + "</b>, the " +

--- a/js/index.test.js
+++ b/js/index.test.js
@@ -47,7 +47,9 @@ beforeEach(() => {
     L = require('leaflet-headless');
     Pattern = require('./leaflet.pattern.js');
     $ = require('jquery');
-    document.body.innerHTML ='<div class="viewport" id="leMap"><div id="map" class="map"></div><div class="year_selector" id="searchbox"></div>';
+    document.body.innerHTML = '<div class="viewport" id="leMap"><div id="map" class="map">' +
+        '</div>' +
+        '<select class="year_selector" id="searchbox"><option value="2016">2015-2016</option></select>';
     var Map = require('./index.js');
     M = new Map("leMap");
 });
@@ -105,6 +107,67 @@ test('style of district that is missing data returns stripes', () => {
     expect(style.color).toBe('#b3b3b3');
     expect(style.fillOpacity).toBe(0.6);
     expect(style.fillPattern).toBe(M.stripes);
+});
+
+test('style of district with higher count than population returns gray', () => {
+    M.processedData = mockData;
+    style = M.getOptions().style(mockFeature(1907));
+    expect(style.fillColor).toEqual('#707070');
+    expect(style.weight).toBe(1);
+    expect(style.opacity).toBe(1);
+    expect(style.color).toBe('#b3b3b3');
+    expect(style.fillOpacity).toBe(0.6);
+    expect(style.fillPattern).toBeFalsy();
+});
+
+test('popup of non-errored district shows normal popup', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(1902), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>In <b>Test District " +
+        "Name</b>, the 43 <b>Black/African American Students</b> received " +
+        "15.22% of the 46 <b>Out of School Suspensions</b> and represented " +
+        "6.91% of the district population.</span>");
+});
+
+test('popup of non-errored district shows normal popup 2', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(1904), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>In <b>Test District " +
+        "Name</b>, the 100 <b>Black/African American Students</b> received " +
+        "2.17% of the 46 <b>Out of School Suspensions</b> and represented " +
+        "16.08% of the district population.</span>");
+});
+
+test('popup of non-errored district shows normal popup 3', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(1905), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>In <b>Test District " +
+        "Name</b>, the 43 <b>Black/African American Students</b> received " +
+        "15.22% of the 46 <b>Out of School Suspensions</b> and represented " +
+        "6.91% of the district population.</span>");
+});
+
+test('popup of district that does not exist shows data not available error', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(101), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>Data not available " +
+        "in <b>Test District Name</b> for " +
+        "<b>Black/African American Students</b> in the <b>2015-2016</b> " +
+        "school year.</span>");
+});
+
+test('popup of district missing data shows data not available error', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(1906), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>Data not available " +
+        "in <b>Test District Name</b> for " +
+        "<b>Black/African American Students</b> in the <b>2015-2016</b> " +
+        "school year.</span>");
 });
 
 test('popup of district with higher count than population shows error', () => {

--- a/js/index.test.js
+++ b/js/index.test.js
@@ -20,6 +20,13 @@ const mockData = {
         aC: 46,
         aP: 622
     },
+    1908: {
+        C: 0,
+        P: 3,
+        S: 0,
+        aC: 46,
+        aP: 622
+    },
     // district with missing data
     1906: {
         P: 923
@@ -148,6 +155,16 @@ test('popup of non-errored district shows normal popup 3', () => {
         "Name</b>, the 43 <b>Black/African American Students</b> received " +
         "15.22% of the 46 <b>Out of School Suspensions</b> and represented " +
         "6.91% of the district population.</span>");
+});
+
+test('popup of non-errored district with count of 0 shows normal popup', () => {
+    M.processedData = mockData;
+    var layer = { bindPopup : jest.fn() };
+    M.getOptions().onEachFeature(mockFeature(1908), layer);
+    expect(layer.bindPopup).toBeCalledWith("<span class='popup-text'>In <b>Test District " +
+        "Name</b>, the 3 <b>Black/African American Students</b> received " +
+        "0% of the 46 <b>Out of School Suspensions</b> and represented " +
+        "0.48% of the district population.</span>");
 });
 
 test('popup of district that does not exist shows data not available error', () => {


### PR DESCRIPTION
- Perhaps the Python data will never have a missing field, but if it does, this change will handle
  it. (I detected this in generating "error" test case data; I have not seen any evidence of this affecting the real site data).
- This modifies the error checking when generating the popup to make sure all data points used are
  not null or undefined.
- The main change is in index.js, but the relevant test case is "popup of district missing data shows data not available error"